### PR TITLE
Update markdown2ctags.py

### DIFF
--- a/tools/markdown2ctags.py
+++ b/tools/markdown2ctags.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2013-2018 John Szakmeister <john@szakmeister.net>
 # All rights reserved.


### PR DESCRIPTION
Making the python version explicit (some Macs still have python 2 installed and it fails there if this isn't set)