### PR TITLE
[fix] quit does not work for 2 windows

### DIFF
--- a/core/autocommands.vim
+++ b/core/autocommands.vim
@@ -101,10 +101,22 @@ augroup END
 
 " Quit Nvim if we have only one window, and its filetype match our pattern.
 function! s:quit_current_win() abort
-  let quit_filetypes = ['qf', 'vista']
-  let buftype = getbufvar(bufnr(), '&filetype')
-  if winnr('$') == 1 && index(quit_filetypes, buftype) != -1
-    quit
+  let l:quit_filetypes = ['qf', 'vista', 'NvimTree']
+
+  let l:should_quit = v:true
+
+  let l:tabwins = nvim_tabpage_list_wins(0)
+  for w in l:tabwins
+    let l:buf = nvim_win_get_buf(w)
+    let l:bf = getbufvar(l:buf, '&filetype')
+
+    if index(l:quit_filetypes, l:bf) == -1
+      let l:should_quit = v:false
+    endif
+  endfor
+
+  if l:should_quit
+    qall
   endif
 endfunction
 


### PR DESCRIPTION
If current buf in remaning two or more windows are filetypes in the quit
list, we should also quit nvim also.