### PR TITLE
update conf related to firenvim

### DIFF
--- a/core/plugins.vim
+++ b/core/plugins.vim
@@ -362,16 +362,20 @@ if exists('g:started_by_firenvim') && g:started_by_firenvim
       \ }
   \ }
 
-  function! s:setup_firenvim() abort
-    set noruler noshowcmd
-    set laststatus=0 showtabline=0
+  function s:setup_firenvim() abort
+    set signcolumn=no
+    set noruler
+    set noshowcmd
+    set laststatus=0
+    set showtabline=0
   endfunction
 
   augroup firenvim
     autocmd!
-    autocmd FileType text call s:setup_firenvim()
-    autocmd BufNewFile github.com_*.txt set filetype=markdown
-    autocmd BufNewFile stackoverflow.com_*.txt set filetype=markdown
+    autocmd BufEnter * call s:setup_firenvim()
+    autocmd BufEnter sqlzoo*.txt set filetype=sql
+    autocmd BufEnter github.com_*.txt set filetype=markdown
+    autocmd BufEnter stackoverflow.com_*.txt set filetype=markdown
   augroup END
 endif
 

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -28,6 +28,11 @@ vim.cmd("packadd packer.nvim")
 local packer = require("packer")
 local packer_util = require("packer.util")
 
+-- check if firenvim is active
+local firenvim_not_active = function()
+  return not vim.g.started_by_firenvim
+end
+
 packer.startup {
   function(use)
     -- it is recommended to put impatient.nvim before any other plugins
@@ -130,13 +135,19 @@ packer.startup {
     use {
       "nvim-lualine/lualine.nvim",
       event = "VimEnter",
+      cond = firenvim_not_active,
       config = [[require('config.statusline')]],
     }
 
-    use { "akinsho/bufferline.nvim", event = "VimEnter", config = [[require('config.bufferline')]] }
+    use { "akinsho/bufferline.nvim", event = "VimEnter",
+      cond = firenvim_not_active,
+      config = [[require('config.bufferline')]] }
 
     -- fancy start screen
-    use { "glepnir/dashboard-nvim", event = "VimEnter", config = [[require('config.dashboard-nvim')]] }
+    use { "glepnir/dashboard-nvim", event = "VimEnter",
+      cond = firenvim_not_active,
+      config = [[require('config.dashboard-nvim')]]
+    }
 
     use {
       "lukas-reineke/indent-blankline.nvim",


### PR DESCRIPTION
1. Change autocmd for buffers started by firenivm, it seems that BufNewFile does not work as intended, in contrast, BufEnter, BufRead, BufWinEnter seem to work.
2. Disable several plugins if we are using firenvim, these plugins include dashboard-nvim, lualine, bufferline.nvim