### PR TITLE
remove vim-asterisk

### DIFF
--- a/lua/config/hlslens.lua
+++ b/lua/config/hlslens.lua
@@ -34,5 +34,15 @@ keymap.set("n", "N", "", {
   end,
 })
 
-keymap.set("n", "*", "<Plug>(asterisk-z*)<Cmd>lua require('hlslens').start()<CR>")
-keymap.set("n", "#", "<Plug>(asterisk-z#)<Cmd>lua require('hlslens').start()<CR>")
+keymap.set("n", "*", "", {
+  callback = function()
+    vim.fn.execute("normal! *N")
+    hlslens.start()
+  end,
+})
+keymap.set("n", "#", "", {
+  callback = function()
+    vim.fn.execute("normal! #N")
+    hlslens.start()
+  end,
+})

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -99,9 +99,6 @@ packer.startup {
       config = [[require('config.hlslens')]],
     }
 
-    -- Stay after pressing * and search selected text
-    use { "haya14busa/vim-asterisk", event = "VimEnter" }
-
     -- File search, tag search and more
     if vim.g.is_win then
       use { "Yggdroot/LeaderF", cmd = "Leaderf" }


### PR DESCRIPTION
The * can now search selected text by default. The cursor stay feature can also be simulated.