### PR TITLE
fix(installer): fix scoop on windows

### DIFF
--- a/docs/nvim_setup_windows.ps1
+++ b/docs/nvim_setup_windows.ps1
@@ -2,7 +2,7 @@
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 
 # Install scoop
-Invoke-WebRequest -UseBasicParsing get.scoop.sh | Invoke-Expression
+echo "$((Invoke-WebRequest -UseBasicParsing get.scoop.sh).Content) -RunAsAdmin" |
 
 # Install node
 scoop install nodejs


### PR DESCRIPTION
Automatically install scoop using the -RunAsAdmin flag on the get.scoop.sh