### PR TITLE
remove language workaround for macOS

### DIFF
--- a/core/globals.lua
+++ b/core/globals.lua
@@ -43,9 +43,7 @@ vim.g.mapleader = ','
 vim.g.vimsyn_embed = 'l'
 
 -- Use English as main language
-if not vim.g.is_mac then
-  vim.cmd [[language en_US.utf-8]]
-end
+vim.cmd [[language en_US.utf-8]]
 
 -- Disable loading certain plugins
 


### PR DESCRIPTION
The issue has been fixed in https://github.com/neovim/neovim/pull/19139.