### PR TITLE
use 2 spaces for tabs by default

### DIFF
--- a/after/ftplugin/cpp.vim
+++ b/after/ftplugin/cpp.vim
@@ -1,10 +1,5 @@
 set commentstring=//\ %s
 
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces
-
 " Disable inserting comment leader after hitting o or O or <Enter>
 set formatoptions-=o
 set formatoptions-=r

--- a/after/ftplugin/javascript.vim
+++ b/after/ftplugin/javascript.vim
@@ -1,8 +1,3 @@
 " Disable inserting comment leader after hitting o or O or <Enter>
 set formatoptions-=o
 set formatoptions-=r
-
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces

--- a/after/ftplugin/lua.vim
+++ b/after/ftplugin/lua.vim
@@ -2,11 +2,6 @@
 set formatoptions-=o
 set formatoptions-=r
 
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces
-
 nnoremap <silent> <F9> :luafile %<CR>
 
 " For delimitMate

--- a/after/ftplugin/python.vim
+++ b/after/ftplugin/python.vim
@@ -8,5 +8,10 @@ set sidescroll=5
 set sidescrolloff=2
 set colorcolumn=100
 
+set tabstop=4       " number of visual spaces per TAB
+set softtabstop=4   " number of spaces in tab when editing
+set shiftwidth=4    " number of spaces to use for autoindent
+set expandtab       " expand tab to spaces so that tabs are spaces
+
 " For delimitMate
 let b:delimitMate_matchpairs = "(:),[:],{:}"

--- a/after/ftplugin/sql.vim
+++ b/after/ftplugin/sql.vim
@@ -1,6 +1,1 @@
 set commentstring=--\ %s
-
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces

--- a/after/ftplugin/toml.vim
+++ b/after/ftplugin/toml.vim
@@ -1,4 +1,0 @@
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces

--- a/after/ftplugin/vim.vim
+++ b/after/ftplugin/vim.vim
@@ -12,9 +12,4 @@ set foldmethod=expr foldexpr=utils#VimFolds(v:lnum) foldtext=utils#MyFoldText()
 " see `:h K` and https://stackoverflow.com/q/15867323/6064933
 set keywordprg=:help
 
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces
-
 nnoremap <silent> <F9> :source %<CR>

--- a/after/ftplugin/yaml.vim
+++ b/after/ftplugin/yaml.vim
@@ -1,8 +1,3 @@
-set tabstop=2       " number of visual spaces per TAB
-set softtabstop=2   " number of spaces in tab when editing
-set shiftwidth=2    " number of spaces to use for autoindent
-set expandtab       " expand tab to spaces so that tabs are spaces
-
 " Turn off syntax highlighting for large YAML files.
 if line('$') > 500
   setlocal syntax=OFF

--- a/core/options.vim
+++ b/core/options.vim
@@ -44,9 +44,9 @@ set backup  " create backup for files
 set backupcopy=yes  " copy the original file to backupdir and overwrite it
 
 " General tab settings
-set tabstop=4       " number of visual spaces per TAB
-set softtabstop=4   " number of spaces in tab when editing
-set shiftwidth=4    " number of spaces to use for autoindent
+set tabstop=2       " number of visual spaces per TAB
+set softtabstop=2   " number of spaces in tab when editing
+set shiftwidth=2    " number of spaces to use for autoindent
 set expandtab       " expand tab to spaces so that tabs are spaces
 
 " Set matching pairs of characters and highlight matching brackets


### PR DESCRIPTION
This removes a lot of code duplication. If we want to use 4 spaces, we can set it separately in their ftplugin settings.