### PR TITLE
fix: cmp-omni messes with the lsp completion

### DIFF
--- a/lua/config/nvim-cmp.lua
+++ b/lua/config/nvim-cmp.lua
@@ -35,7 +35,6 @@ cmp.setup {
     { name = "ultisnips" }, -- For ultisnips user.
     { name = "path" }, -- for path completion
     { name = "buffer", keyword_length = 2 }, -- for buffer word completion
-    { name = "omni" },
     { name = "emoji", insert = true }, -- emoji completion
   },
   completion = {
@@ -60,6 +59,15 @@ cmp.setup {
     },
   },
 }
+
+cmp.setup.filetype("tex", {
+  sources = {
+    { name = "omni" },
+    { name = "ultisnips" }, -- For ultisnips user.
+    { name = "buffer", keyword_length = 2 }, -- for buffer word completion
+    { name = "path" }, -- for path completion
+  },
+})
 
 --  see https://github.com/hrsh7th/nvim-cmp/wiki/Menu-Appearance#how-to-add-visual-studio-code-dark-theme-colors-to-the-menu
 vim.cmd([[


### PR DESCRIPTION
If we use cmp-omni and lsp together, it seems that it will mess the autocompletion. So we only use it with tex file, where lsp in not used.