### PR TITLE
fix: omit the clangd missing message, close #180

### DIFF
--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -154,8 +154,6 @@ if utils.executable("clangd") then
       debounce_text_changes = 500,
     },
   }
-else
-  vim.notify("clangd not found!", vim.log.levels.WARN, { title = "Nvim-config" })
 end
 
 -- set up vim-language-server


### PR DESCRIPTION
It is not necessary to install clangd if the user does not use neovim with CPP/C.