### PR TITLE
nvim-tree: fix shortcut and repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ and how to set up on different platforms (Linux, macOS, and Windows).
 + Fast buffer jump via [hop.nvim](https://github.com/phaazon/hop.nvim).
 + Powerful snippet insertion via [Ultisnips](https://github.com/SirVer/ultisnips).
 + Beautiful statusline via [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim).
-+ File tree explorer via [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua).
++ File tree explorer via [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua).
 + Better quickfix list with [nvim-bqf](https://github.com/kevinhwang91/nvim-bqf).
 + Show search index and count with [nvim-hlslens](https://github.com/kevinhwang91/nvim-hlslens).
 + Command line auto-completion via [wilder.nvim](https://github.com/gelguy/wilder.nvim).

--- a/lua/config/nvim-tree.lua
+++ b/lua/config/nvim-tree.lua
@@ -113,6 +113,7 @@ nvim_tree.setup {
   },
 }
 
-keymap.set("n", "<space>s", function()
-  return require("nvim-tree").toggle(false, true)
-end, { silent = true, desc = "toggle nvim-tree" })
+keymap.set("n", "<space>s", require("nvim-tree.api").tree.toggle, {
+  silent = true,
+  desc = "toggle nvim-tree",
+})

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -137,7 +137,7 @@ packer.startup {
     use { "tanvirtin/monokai.nvim", opt = true }
     use { "marko-cerovac/material.nvim", opt = true }
 
-    use { "kyazdani42/nvim-web-devicons", event = "VimEnter" }
+    use { "nvim-tree/nvim-web-devicons", event = "VimEnter" }
 
     use {
       "nvim-lualine/lualine.nvim",

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -358,8 +358,8 @@ packer.startup {
 
     -- file explorer
     use {
-      "kyazdani42/nvim-tree.lua",
-      requires = { "kyazdani42/nvim-web-devicons" },
+      "nvim-tree/nvim-tree.lua",
+      requires = { "nvim-tree/nvim-web-devicons" },
       config = [[require('config.nvim-tree')]],
     }
 


### PR DESCRIPTION
Two changes for nvim-tree:

1. `require("nvim-tree").toggle(false, true)` was removed about 2 weeks ago. 
    * After running `PackerSync` yesterday, I started getting the error `lua/config/nvim-tree.lua:117: attempt to call field 'toggle' (a nil value)`.
    * see https://github.com/nvim-tree/nvim-tree.lua/issues/2054#issuecomment-1467031808


2. kyazdani42 has redirected their repos to nvim-tree/nvim-tree