### PR TITLE
fix: missing nerdfonts

### DIFF
--- a/lua/config/bufferline.lua
+++ b/lua/config/bufferline.lua
@@ -9,7 +9,7 @@ require("bufferline").setup {
       icon = "▎", -- this should be omitted if indicator style is not 'icon'
       style = "icon",
     },
-    buffer_close_icon = "",
+    buffer_close_icon = "",
     modified_icon = "●",
     close_icon = "",
     left_trunc_marker = "",

--- a/lua/config/dashboard-nvim.lua
+++ b/lua/config/dashboard-nvim.lua
@@ -21,25 +21,25 @@ conf.header = {
 
 conf.center = {
   {
-    icon = "  ",
+    icon = "󰈞  ",
     desc = "Find  File                              ",
     action = "Leaderf file --popup",
     key = "<Leader> f f",
   },
   {
-    icon = "  ",
+    icon = "󰈢  ",
     desc = "Recently opened files                   ",
     action = "Leaderf mru --popup",
     key = "<Leader> f r",
   },
   {
-    icon = "  ",
+    icon = "󰈬  ",
     desc = "Project grep                            ",
     action = "Leaderf rg --popup",
     key = "<Leader> f g",
   },
   {
-    icon = "  ",
+    icon = "  ",
     desc = "Open Nvim config                        ",
     action = "tabnew $MYVIMRC | tcd %:p:h",
     key = "<Leader> e v",
@@ -51,7 +51,7 @@ conf.center = {
     key = "e",
   },
   {
-    icon = "  ",
+    icon = "󰗼  ",
     desc = "Quit Nvim                               ",
     -- desc = "Quit Nvim                               ",
     action = "qa",

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -233,10 +233,10 @@ if utils.executable("lua-language-server") then
 end
 
 -- Change diagnostic signs.
-fn.sign_define("DiagnosticSignError", { text = "✗", texthl = "DiagnosticSignError" })
-fn.sign_define("DiagnosticSignWarn", { text = "!", texthl = "DiagnosticSignWarn" })
-fn.sign_define("DiagnosticSignInformation", { text = "", texthl = "DiagnosticSignInfo" })
-fn.sign_define("DiagnosticSignHint", { text = "", texthl = "DiagnosticSignHint" })
+fn.sign_define("DiagnosticSignError", { text = '🆇', texthl = "DiagnosticSignError" })
+fn.sign_define("DiagnosticSignWarn", { text = '⚠️', texthl = "DiagnosticSignWarn" })
+fn.sign_define("DiagnosticSignInfo", { text = 'ℹ️', texthl = "DiagnosticSignInfo" })
+fn.sign_define("DiagnosticSignHint", { text = '', texthl = "DiagnosticSignHint" })
 
 -- global config for diagnostic
 diagnostic.config {

--- a/lua/config/statusline.lua
+++ b/lua/config/statusline.lua
@@ -130,6 +130,7 @@ require("lualine").setup {
       {
         "diagnostics",
         sources = { "nvim_diagnostic" },
+        symbols = {error = '🆇 ', warn = '⚠️ ', info = 'ℹ️ ', hint = ' '},
       },
     },
     lualine_x = {


### PR DESCRIPTION
Since wezterm upgrade its support for Nerd Fonts 3.0, we should update the codepoints used for some of the Unicode Icons. Their code points are changed due to breaking changes in Nerd Fonts.