### PR TITLE
fix: user lua conf reloading fails

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -43,6 +43,7 @@ for _, file_name in ipairs(core_conf_files) do
     vim.cmd(source_cmd)
   else
     local module_name, _ = string.gsub(file_name, "%.lua", "")
+    package.loaded[module_name] = nil
     require(module_name)
   end
 end


### PR DESCRIPTION
The cache should be invalidated. This fix does not work 100%, because, e.g., there are other configs hiding deeper under lua/config/ directory. A restart is the best way to reload the config.