### PR TITLE
fix multi-line yank issue, close #220

### DIFF
--- a/lua/custom-autocmd.lua
+++ b/lua/custom-autocmd.lua
@@ -17,11 +17,28 @@ api.nvim_create_autocmd({ "BufRead" }, {
 })
 
 -- highlight yanked region, see `:h lua-highlight`
+local yank_group = api.nvim_create_augroup("highlight_yank", { clear = true })
 api.nvim_create_autocmd({ "TextYankPost" }, {
   pattern = "*",
-  group = api.nvim_create_augroup("highlight_yank", { clear = true }),
+  group = yank_group,
   callback = function()
     vim.highlight.on_yank { higroup = "YankColor", timeout = 300 }
+  end,
+})
+
+api.nvim_create_autocmd({ "CursorMoved" }, {
+  pattern = "*",
+  group = yank_group,
+  callback = function()
+    vim.g.current_cursor_pos = vim.fn.getcurpos()
+  end,
+})
+
+api.nvim_create_autocmd("TextYankPost", {
+  pattern = "*",
+  group = yank_group,
+  callback = function(ev)
+    vim.fn.setpos('.', vim.g.current_cursor_pos)
   end,
 })
 

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -201,20 +201,6 @@ end
 -- insert semicolon in the end
 keymap.set("i", "<A-;>", "<Esc>miA;<Esc>`ii")
 
--- Keep cursor position after yanking
-keymap.set("n", "y", "myy")
-
-api.nvim_create_autocmd("TextYankPost", {
-  pattern = "*",
-  group = api.nvim_create_augroup("restore_after_yank", { clear = true }),
-  callback = function()
-    vim.cmd([[
-      silent! normal! `y
-      silent! delmarks y
-    ]])
-  end,
-})
-
 -- Go to the beginning and end of current line in insert mode quickly
 keymap.set("i", "<C-A>", "<HOME>")
 keymap.set("i", "<C-E>", "<END>")


### PR DESCRIPTION
The previous way of keep the cursor while yanking is not perfect. It will break multi-line yank (`{count}yy`).