### PR TITLE
fix multi visual line delete issue

### DIFF
--- a/lua/custom-autocmd.lua
+++ b/lua/custom-autocmd.lua
@@ -38,7 +38,9 @@ api.nvim_create_autocmd("TextYankPost", {
   pattern = "*",
   group = yank_group,
   callback = function(ev)
-    vim.fn.setpos('.', vim.g.current_cursor_pos)
+    if vim.v.event.operator == 'y' then
+      vim.fn.setpos('.', vim.g.current_cursor_pos)
+    end
   end,
 })
 


### PR DESCRIPTION
For TextYankPost event, it includes both yank and delete, we should only restore cursor position for yank, not for delete. Otherwise, it messes up with text deletion when you visually select multiple lines and delete them. See also issue reported here: https://github.com/jdhao/nvim-config/pull/222#issuecomment-1698634645