### PR TITLE
fix bufferline loading issue

### DIFF
--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -151,7 +151,7 @@ require("lazy").setup {
 
   {
     "akinsho/bufferline.nvim",
-    event = "VeryLazy",
+    event = { "BufRead", "BufNewFile" } ,
     cond = firenvim_not_active,
     config = function()
       require("config.bufferline")


### PR DESCRIPTION
It seems that if we use `VeryLazy` for bufferline, it will not work properly.