### PR TITLE
Enable nvim-tree to open dir during startup

### DIFF
--- a/lua/config/nvim-tree.lua
+++ b/lua/config/nvim-tree.lua
@@ -4,8 +4,8 @@ local nvim_tree = require("nvim-tree")
 nvim_tree.setup {
   auto_reload_on_write = true,
   disable_netrw = false,
-  hijack_cursor = false,
   hijack_netrw = true,
+  hijack_cursor = false,
   hijack_unnamed_buffer_when_opening = false,
   open_on_tab = false,
   sort_by = "name",

--- a/lua/custom-autocmd.lua
+++ b/lua/custom-autocmd.lua
@@ -83,3 +83,23 @@ api.nvim_create_autocmd("VimResized", {
   desc = "autoresize windows on resizing operation",
   command = "wincmd =",
 })
+
+local function open_nvim_tree(data)
+  -- check if buffer is a directory
+  local directory = vim.fn.isdirectory(data.file) == 1
+
+  if not directory then
+    return
+  end
+
+  -- create a new, empty buffer
+  vim.cmd.enew()
+
+  -- wipe the directory buffer
+  vim.cmd.bw(data.buf)
+
+  -- open the tree
+  require("nvim-tree.api").tree.open()
+end
+
+vim.api.nvim_create_autocmd({ "VimEnter" }, { callback = open_nvim_tree })


### PR DESCRIPTION
Now when you open a directory when starting nvim, nvim-tree will be opened to handle the directory correctly, see also issue #257.