### PR TITLE
add nvim-ufo for folding

### DIFF
--- a/after/ftplugin/json.vim
+++ b/after/ftplugin/json.vim
@@ -1,6 +1,2 @@
 " let the initial folding state be that all folds are closed.
-set foldlevel=0
-
-" Use nvim-treesitter for folding
-set foldmethod=expr
-set foldexpr=nvim_treesitter#foldexpr()
+setlocal foldlevel=0

--- a/lua/config/ufo.lua
+++ b/lua/config/ufo.lua
@@ -1,0 +1,14 @@
+ -- disable foldcolumn, see https://github.com/kevinhwang91/nvim-ufo/issues/4
+vim.o.foldcolumn = '0'
+vim.o.foldlevel = 99 -- Using ufo provider need a large value, feel free to decrease the value
+vim.o.foldlevelstart = 99
+vim.o.foldenable = true
+
+-- treesitter as a main provider instead
+-- Only depend on `nvim-treesitter/queries/filetype/folds.scm`,
+-- performance and stability are better than `foldmethod=nvim_treesitter#foldexpr()`
+require('ufo').setup({
+    provider_selector = function(bufnr, filetype, buftype)
+        return {'treesitter', 'indent'}
+    end
+})

--- a/lua/config/ufo.lua
+++ b/lua/config/ufo.lua
@@ -1,8 +1,10 @@
- -- disable foldcolumn, see https://github.com/kevinhwang91/nvim-ufo/issues/4
+local keymap = vim.keymap
+
+-- disable foldcolumn, see https://github.com/kevinhwang91/nvim-ufo/issues/4
 vim.o.foldcolumn = '0'
 vim.o.foldlevel = 99 -- Using ufo provider need a large value, feel free to decrease the value
 vim.o.foldlevelstart = 99
-vim.o.foldenable = true
+vim.o.foldenable = true -- Don't set nofoldenable in ftplugin
 
 -- treesitter as a main provider instead
 -- Only depend on `nvim-treesitter/queries/filetype/folds.scm`,
@@ -12,3 +14,9 @@ require('ufo').setup({
         return {'treesitter', 'indent'}
     end
 })
+
+local ufo = require('ufo')
+keymap.set('n', 'zR', ufo.openAllFolds, { desc = 'Open all folds' })
+keymap.set('n', 'zM', ufo.closeAllFolds, { desc = 'Close all folds' })
+keymap.set('n', 'zr', ufo.openFoldsExceptKinds, { desc = 'Fold less' })
+keymap.set('n', 'zm', ufo.closeFoldsWith, { desc = 'Fold more' })

--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -50,7 +50,7 @@ local plugin_specs = {
   {
     "nvim-treesitter/nvim-treesitter",
     enabled = function()
-      if vim.g.is_mac then
+      if vim.g.is_mac or vim.g.is_linux then
         return true
       end
       return false
@@ -488,6 +488,14 @@ local plugin_specs = {
       require("config.fidget-nvim")
     end,
   },
+  {
+    'kevinhwang91/nvim-ufo',
+    dependencies = {'kevinhwang91/promise-async'},
+    event = { "VeryLazy" },
+    config = function()
+      require("config.ufo")
+    end
+  }
 }
 
 -- configuration for lazy itself.


### PR DESCRIPTION
`foldexpr=nvim_treesitter#foldexpr()` is unstable and buggy. I spotted a problem with treesitter folding: the foldings are not updated after I changed the file, and I have to `:e` for the folding structure to reload.

Occasionally the treesitter fold closes the region where I have just editted (in python etc.)

I use `kevinhwang91/nvim-ufo` for more reliable folding. It can utilize treesitter (or LSP) as its
backend, and work with the default `foldexpr=manual`. More customization is also available, such as getting a foldcolumn like VSCode.