### PR TITLE
update some mappings

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -170,7 +170,7 @@ keymap.set("n", "<Down>", "<C-W>j")
 keymap.set({ "x", "o" }, "iu", "<cmd>call text_obj#URL()<cr>", { desc = "URL text object" })
 
 -- Text objects for entire buffer
-keymap.set({ "x", "o" }, "iB", "<cmd>call text_obj#Buffer()<cr>", { desc = "buffer text object" })
+keymap.set({ "x", "o" }, "iB", ":<C-U>call text_obj#Buffer()<cr>", { desc = "buffer text object" })
 
 -- Do not move my cursor when joining lines.
 keymap.set("n", "J", function()
@@ -179,17 +179,17 @@ keymap.set("n", "J", function()
       delmarks z
     ]])
 end, {
-  desc = "join line",
+  desc = "join lines without moving cursor",
 })
 
 keymap.set("n", "gJ", function()
   -- we must use `normal!`, otherwise it will trigger recursive mapping
   vim.cmd([[
-      normal! zmgJ`z
+      normal! mzgJ`z
       delmarks z
     ]])
 end, {
-  desc = "join visual lines",
+  desc = "join lines without moving cursor",
 })
 
 -- Break inserted text into smaller undo units when we insert some punctuation chars.


### PR DESCRIPTION
1. fix a typo in gJ mapping when setting the mark, the correct syntax is `mz` (set mark `z`), not `zm`

2. fix bug with `iB` text object: previously `viB` does not work as expected, because it does not select the entire buffer as expected. After much investigation, I found it is because the `<cmd>` mapping argument. If we use `<cmd>` argument for mapping, the mode does not change. So if we use `viB`, inititally we are still in visual mode. Later in the implementation, when we use `` normal! `<V`>  `` to select the entire buffer, it interferes with original visual mode. As a result, the entire buffer is not selected. In the text obj implementation, we can use `exe "normal! \<Esc>"` to clear the visual mode and make `viB`, but this is not ideal. I think it is eaiser to just not use the `<cmd>` argument and use `:<C-U>` instead.