### PR TITLE
upgrade neovim to latest stable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -14,11 +14,13 @@ vim.loader.enable()
 local version = vim.version
 
 -- check if we have the latest stable version of nvim
-local expected_ver = "0.9.5"
+local expected_ver = "0.10.0"
 local ev = version.parse(expected_ver)
 local actual_ver = version()
 
-if version.cmp(ev, actual_ver) ~= 0 then
+local result = version.cmp(ev, {actual_ver.major, actual_ver.minor, actual_ver.patch})
+
+if  result ~= 0 then
   local _ver = string.format("%s.%s.%s", actual_ver.major, actual_ver.minor, actual_ver.patch)
   local msg = string.format("Expect nvim %s, but got %s instead. Use at your own risk!", expected_ver, _ver)
   vim.api.nvim_err_writeln(msg)


### PR DESCRIPTION
The way to compare versions are changed due to a bug in comparing versions in the neovim core: https://github.com/neovim/neovim/issues/28782