### PR TITLE
filter fold level sign for statuscol.nvim

### DIFF
--- a/lua/config/nvim-statuscol.lua
+++ b/lua/config/nvim-statuscol.lua
@@ -1,0 +1,23 @@
+local builtin = require("statuscol.builtin")
+local ffi = require("statuscol.ffidef")
+local C = ffi.C
+
+-- only show fold level up to this level
+local fold_level_limit = 2
+local function foldfunc(args)
+  local foldinfo = C.fold_info(args.wp, args.lnum)
+  if foldinfo.level > fold_level_limit then
+    return " "
+  end
+
+  return builtin.foldfunc(args)
+end
+
+require("statuscol").setup {
+  relculright = false,
+  segments = {
+    { text = { "%s" }, click = "v:lua.ScSa" },
+    { text = { builtin.lnumfunc, " " }, click = "v:lua.ScLa" },
+    { text = { foldfunc, " " }, condition = { true, builtin.not_empty }, click = "v:lua.ScFa" },
+  },
+}

--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -190,15 +190,7 @@ local plugin_specs = {
     "luukvbaal/statuscol.nvim",
     opts = {},
     config = function()
-      local builtin = require("statuscol.builtin")
-      require("statuscol").setup {
-        relculright = true,
-        segments = {
-          { text = { "%s" }, click = "v:lua.ScSa" },
-          { text = { builtin.lnumfunc, " " }, click = "v:lua.ScLa" },
-          { text = { builtin.foldfunc, " " }, condition = {true, builtin.not_empty}, click = "v:lua.ScFa" },
-        },
-      }
+      require("config.nvim-statuscol")
     end,
   },
   {


### PR DESCRIPTION
Only show fold signs for fold level below a certain level to avoid clutter the left side columns with a lot of folding signs