### PR TITLE
Update configuration for nvim-cmp

### DIFF
--- a/lua/config/nvim-cmp.lua
+++ b/lua/config/nvim-cmp.lua
@@ -35,7 +35,6 @@ cmp.setup {
     { name = "ultisnips" }, -- For ultisnips user.
     { name = "path" }, -- for path completion
     { name = "buffer", keyword_length = 2 }, -- for buffer word completion
-    { name = "emoji", insert = true }, -- emoji completion
   },
   completion = {
     keyword_length = 1,
@@ -50,12 +49,14 @@ cmp.setup {
       menu = {
         nvim_lsp = "[LSP]",
         ultisnips = "[US]",
-        nvim_lua = "[Lua]",
         path = "[Path]",
         buffer = "[Buffer]",
         emoji = "[Emoji]",
         omni = "[Omni]",
       },
+      show_labelDetails = true,
+      maxwidth = 40,
+      ellipsis_char = "...",
     },
   },
 }

--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -32,7 +32,6 @@ local plugin_specs = {
       "hrsh7th/cmp-path",
       "hrsh7th/cmp-buffer",
       "hrsh7th/cmp-omni",
-      "hrsh7th/cmp-emoji",
       "quangnguyen30192/cmp-nvim-ultisnips",
     },
     config = function()

--- a/viml_conf/options.vim
+++ b/viml_conf/options.vim
@@ -121,7 +121,7 @@ set completeopt+=menuone  " Show menu even if there is only one item
 set completeopt-=preview  " Disable the preview window
 
 set pumheight=10  " Maximum number of items to show in popup menu
-set pumblend=10  " pseudo transparency for completion menu
+set pumblend=5  " pseudo transparency for completion menu
 
 set winblend=0  " pseudo transparency for floating window
 


### PR DESCRIPTION
1. restrict max width of the completion menu. Here I am using lspkind.nvim to achieve this. There are other native ways to do this, see also https://github.com/hrsh7th/nvim-cmp/discussions/609 and https://github.com/hrsh7th/nvim-cmp/issues/980
2. remove cmp-emoji as it is rarely used and interfere when I write Python
3. lower the transparency for popup menu