### PR TITLE
Make * and # search case aware

### DIFF
--- a/lua/config/hlslens.lua
+++ b/lua/config/hlslens.lua
@@ -35,33 +35,48 @@ keymap.set("n", "N", "", {
   end,
 })
 
-local no_word_under_cursor = function()
+local check_cursor_word = function()
   local cursor_word = vim.fn.expand("<cword>")
-
   local result = cursor_word == ""
   if result then
     local msg = "E348: No string under cursor"
     api.nvim_err_writeln(msg)
   end
 
-  return result
+  return result, cursor_word
 end
 
 keymap.set("n", "*", "", {
   callback = function()
-    if no_word_under_cursor() then
+    local cursor_word_empty, cursor_word = check_cursor_word()
+    if cursor_word_empty then
       return
     end
-    vim.fn.execute("normal! *N")
+
+    local cmd = string.format([[normal! /\v<%s>]], cursor_word)
+
+    -- In order to say that we are pressing Enter key, instead of typing literally the character,
+    -- we need to replace special notation with their internal representation.
+    local escaped_enter = vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+
+    -- character `N` is used to keep the cursor when pressing `*`
+    local full_cmd = cmd .. escaped_enter .. "N"
+    vim.fn.execute(full_cmd)
     hlslens.start()
   end,
 })
 keymap.set("n", "#", "", {
   callback = function()
-    if no_word_under_cursor() then
+    local cursor_word_empty, cursor_word = check_cursor_word()
+    if cursor_word_empty then
       return
     end
-    vim.fn.execute("normal! #N")
+
+    local cmd = string.format([[normal! ?\v<%s>]], cursor_word)
+    local escaped_enter = vim.api.nvim_replace_termcodes("<CR>", true, false, true)
+
+    local full_cmd = cmd .. escaped_enter .. "N"
+    vim.fn.execute(full_cmd)
     hlslens.start()
   end,
 })


### PR DESCRIPTION
By default, when you press `*` to search word under the cursor, the option `smartcase` is ignored. This means that if you press `*` when your cursor is on `The`, the lower case one `the` is also searched.

In this commit, we translate star and # search into normal search so that 'smartcase' option is respected.