### PR TITLE
remove inspect() from lua _G table

### DIFF
--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -43,7 +43,7 @@ local custom_attach = function(client, bufnr)
   map("n", "<space>wa", vim.lsp.buf.add_workspace_folder, { desc = "add workspace folder" })
   map("n", "<space>wr", vim.lsp.buf.remove_workspace_folder, { desc = "remove workspace folder" })
   map("n", "<space>wl", function()
-    inspect(vim.lsp.buf.list_workspace_folders())
+    vim.print(vim.lsp.buf.list_workspace_folders())
   end, { desc = "list workspace folder" })
 
   -- Set some key bindings conditional on server capabilities

--- a/lua/globals.lua
+++ b/lua/globals.lua
@@ -3,11 +3,6 @@ local api = vim.api
 
 local utils = require('utils')
 
--- Inspect something
-function _G.inspect(item)
-  vim.print(item)
-end
-
 ------------------------------------------------------------------------
 --                          custom variables                          --
 ------------------------------------------------------------------------


### PR DESCRIPTION
Nvim nows provides `vim.inspect()` and `vim.print()`.