### PR TITLE
Use absolute path for viml config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,15 +16,18 @@ local utils = require("utils")
 local expected_version = "0.10.1"
 utils.is_compatible_version(expected_version)
 
+local config_dir = vim.fn.stdpath("config")
+---@cast config_dir string
+
 -- some global settings
 require("globals")
 -- setting options in nvim
-vim.cmd("source viml_conf/options.vim")
+vim.cmd("source " .. vim.fs.joinpath(config_dir, "viml_conf/options.vim"))
 -- various autocommands
 require("custom-autocmd")
 -- all the user-defined mappings
 require("mappings")
 -- all the plugins installed and their configurations
-vim.cmd("source viml_conf/plugins.vim")
+vim.cmd("source ".. vim.fs.joinpath(config_dir, "viml_conf/plugins.vim"))
 -- colorscheme settings
 require("colorschemes")


### PR DESCRIPTION
Full path should be used to load viml config, otherwise, when we open nvim in other directories, we see errors that the viml config can not be found.