### PR TITLE
enable inlayhint for lua_ls server

### DIFF
--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -51,6 +51,10 @@ local custom_attach = function(client, bufnr)
     map("n", "<space>f", vim.lsp.buf.format, { desc = "format code" })
   end
 
+  -- Uncomment code below to enable inlay hint from language server, some LSP server supports inlay hint,
+  -- but disable this feature by default, so you may need to enable inlay hint in the LSP server config.
+  -- vim.lsp.inlay_hint.enable(true, {buffer=bufnr})
+
   api.nvim_create_autocmd("CursorHold", {
     buffer = bufnr,
     callback = function()
@@ -220,8 +224,8 @@ if utils.executable("bash-language-server") then
   }
 end
 
+-- settings for lua-language-server can be found on https://luals.github.io/wiki/settings/
 if utils.executable("lua-language-server") then
-  -- settings for lua-language-server can be found on https://github.com/LuaLS/lua-language-server/wiki/Settings .
   lspconfig.lua_ls.setup {
     on_attach = custom_attach,
     settings = {
@@ -230,6 +234,9 @@ if utils.executable("lua-language-server") then
           -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
           version = "LuaJIT",
         },
+        hint = {
+          enable = true
+        }
       },
     },
     capabilities = capabilities,


### PR DESCRIPTION
The client side inlayhint can be enabled by uncommentting the code in this PR.