### PR TITLE
silently format lua file using stylua

### DIFF
--- a/after/ftplugin/lua.vim
+++ b/after/ftplugin/lua.vim
@@ -4,4 +4,4 @@ set formatoptions-=r
 
 nnoremap <buffer><silent> <F9> :luafile %<CR>
 
-nnoremap <buffer><silent> <space>f <cmd>!stylua %<CR>
+nnoremap <buffer><silent> <space>f <cmd>silent !stylua %<CR>

--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -50,7 +50,7 @@ local custom_attach = function(client, bufnr)
   end, { desc = "list workspace folder" })
 
   -- Set some key bindings conditional on server capabilities
-  if client.server_capabilities.documentFormattingProvider then
+  if client.server_capabilities.documentFormattingProvider and client.name ~= "lua_ls" then
     map({ "n", "x" }, "<space>f", vim.lsp.buf.format, { desc = "format code" })
   end
 


### PR DESCRIPTION
We need to disable the mapping set for LSP, otherwise the mapping set in lua.vim will be overridden.