### PR TITLE
fix gitsign word_diff flickering issue

### DIFF
--- a/lua/config/gitsigns.lua
+++ b/lua/config/gitsigns.lua
@@ -8,7 +8,7 @@ gs.setup {
     topdelete = { text = "‾" },
     changedelete = { text = "│" },
   },
-  word_diff = true,
+  word_diff = false,
   on_attach = function(bufnr)
     local function map(mode, l, r, opts)
       opts = opts or {}
@@ -38,10 +38,10 @@ gs.setup {
     end, { expr = true, desc = "previous hunk" })
 
     -- Actions
-    map("n", "<leader>hp", gs.preview_hunk)
+    map("n", "<leader>hp", gs.preview_hunk, { desc = "preview hunk" })
     map("n", "<leader>hb", function()
       gs.blame_line { full = true }
-    end)
+    end, { desc = "blame hunk" })
   end,
 }
 

--- a/lua/config/lualine.lua
+++ b/lua/config/lualine.lua
@@ -42,7 +42,9 @@ local async_git_status_update = function()
   async_cmd(ahead_cmd_str, handle_numeric_result("ahead_count"))
 end
 
-local function get_ahead_behind_info()
+local function get_git_ahead_behind_info()
+  async_git_status_update()
+
   local status = git_status_cache
   if not status then
     return ""
@@ -62,9 +64,6 @@ local function get_ahead_behind_info()
 
   return msg
 end
-
-local timer = vim.loop.new_timer()
-timer:start(0, 1000, async_git_status_update)
 
 local function spell()
   if vim.o.spell then
@@ -210,6 +209,9 @@ require("lualine").setup {
     section_separators = "",
     disabled_filetypes = {},
     always_divide_middle = true,
+    refresh = {
+      statusline = 500,
+    },
   },
   sections = {
     lualine_a = {
@@ -230,7 +232,7 @@ require("lualine").setup {
         color = { gui = "italic,bold" },
       },
       {
-        get_ahead_behind_info,
+        get_git_ahead_behind_info,
         color = { fg = "#E0C479" },
       },
       {


### PR DESCRIPTION
I guess it is due to the reason that we are doing constant git fetch, and somehow gitsigns word diff is affected.

Changing the gitsigns debounce or changing lualine refresh rate do not seem to help. So gitsigns word diff is disabled.