### PR TITLE
Install Treesitter on all systems

### DIFF
--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -50,12 +50,6 @@ local plugin_specs = {
 
   {
     "nvim-treesitter/nvim-treesitter",
-    enabled = function()
-      if vim.g.is_mac then
-        return true
-      end
-      return false
-    end,
     event = "VeryLazy",
     build = ":TSUpdate",
     config = function()


### PR DESCRIPTION
It's my first time using neovim. I use archlinux and got some errors using this setup since treesitter will only be installed on mac os. This conflicts with treesitter-textobjects which gets installed for every system.

With this change treesitter will be installed on every system.