### PR TITLE
Use new lsp configuration structure

### DIFF
--- a/after/lsp/bashls.lua
+++ b/after/lsp/bashls.lua
@@ -1,0 +1,5 @@
+local lsp_utils = require("lsp_utils")
+
+return {
+  capabilities = lsp_utils.get_default_capabilities(),
+}

--- a/after/lsp/clangd.lua
+++ b/after/lsp/clangd.lua
@@ -1,0 +1,9 @@
+local lsp_utils = require("lsp_utils")
+
+return {
+  filetypes = { "c", "cpp", "cc" },
+  flags = {
+    debounce_text_changes = 500,
+  },
+  capabilities = lsp_utils.get_default_capabilities(),
+}

--- a/after/lsp/ltex.lua
+++ b/after/lsp/ltex.lua
@@ -1,0 +1,12 @@
+local lsp_utils = require("lsp_utils")
+
+return {
+  filetypes = { "text", "plaintex", "tex", "markdown" },
+  settings = {
+    ltex = {
+      language = "en",
+    },
+  },
+  flags = { debounce_text_changes = 300 },
+  capabilities = lsp_utils.get_default_capabilities(),
+}

--- a/after/lsp/lua_ls.lua
+++ b/after/lsp/lua_ls.lua
@@ -1,0 +1,17 @@
+local lsp_utils = require("lsp_utils")
+
+-- settings for lua-language-server can be found on https://luals.github.io/wiki/settings/
+return {
+  settings = {
+    Lua = {
+      runtime = {
+        -- Tell the language server which version of Lua you're using (most likely LuaJIT in the case of Neovim)
+        version = "LuaJIT",
+      },
+      hint = {
+        enable = true,
+      },
+    },
+  },
+  capabilities = lsp_utils.get_default_capabilities(),
+}

--- a/after/lsp/pyright.lua
+++ b/after/lsp/pyright.lua
@@ -1,0 +1,56 @@
+local lsp_utils = require("lsp_utils")
+
+-- For what diagnostic is enabled in which type checking mode, check doc:
+-- https://github.com/microsoft/pyright/blob/main/docs/configuration.md#diagnostic-settings-defaults
+-- Currently, the pyright also has some issues displaying hover documentation:
+-- https://www.reddit.com/r/neovim/comments/1gdv1rc/what_is_causeing_the_lsp_hover_docs_to_looks_like/
+
+local new_capability = {
+  -- this will remove some of the diagnostics that duplicates those from ruff, idea taken and adapted from
+  -- here: https://github.com/astral-sh/ruff-lsp/issues/384#issuecomment-1989619482
+  textDocument = {
+    publishDiagnostics = {
+      tagSupport = {
+        valueSet = { 2 },
+      },
+    },
+    hover = {
+      contentFormat = { "plaintext" },
+      dynamicRegistration = true,
+    },
+  },
+}
+
+local capabilities = lsp_utils.get_default_capabilities()
+local merged_capability = vim.tbl_deep_extend("force", capabilities, new_capability)
+
+return {
+  cmd = { "delance-langserver", "--stdio" },
+  settings = {
+    pyright = {
+      -- disable import sorting and use Ruff for this
+      disableOrganizeImports = true,
+      disableTaggedHints = false,
+    },
+    python = {
+      analysis = {
+        autoSearchPaths = true,
+        diagnosticMode = "workspace",
+        typeCheckingMode = "standard",
+        useLibraryCodeForTypes = true,
+        -- we can this setting below to redefine some diagnostics
+        diagnosticSeverityOverrides = {
+          deprecateTypingAliases = false,
+        },
+        -- inlay hint settings are provided by pylance?
+        inlayHints = {
+          callArgumentNames = "partial",
+          functionReturnTypes = true,
+          pytestParameters = true,
+          variableTypes = true,
+        },
+      },
+    },
+  },
+  capabilities = merged_capability,
+}

--- a/after/lsp/ruff.lua
+++ b/after/lsp/ruff.lua
@@ -1,0 +1,11 @@
+local lsp_utils = require("lsp_utils")
+
+return {
+  init_options = {
+    -- the settings can be found here: https://docs.astral.sh/ruff/editors/settings/
+    settings = {
+      organizeImports = true,
+    },
+  },
+  capabilities = lsp_utils.get_default_capabilities(),
+}

--- a/after/lsp/vimls.lua
+++ b/after/lsp/vimls.lua
@@ -1,0 +1,8 @@
+local lsp_utils = require("lsp_utils")
+
+return {
+  flags = {
+    debounce_text_changes = 500,
+  },
+  capabilities = lsp_utils.get_default_capabilities(),
+}

--- a/lua/lsp_utils.lua
+++ b/lua/lsp_utils.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+M.get_default_capabilities = function()
+  local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+  -- required by nvim-ufo
+  capabilities.textDocument.foldingRange = {
+    dynamicRegistration = false,
+    lineFoldingOnly = true,
+  }
+
+  return capabilities
+end
+
+return M


### PR DESCRIPTION
In this new structure, the main configuration for a LSP server is provided by the plugin nvim-lspconfig.
Some of the config may be overridden by the configuration under directory `after/lsp/xxx.lua`, where `xxx` is the lsp server name used by nvim-lspconfig.

Note that it is necessary to put the custom lsp server configuration under `after/` directory, in order to correctly override the config provided by nvim-lspconfig.