### PR TITLE
Fix filetype detection issue for nvim 0.11.2

### DIFF
--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -101,7 +101,6 @@ local plugin_specs = {
   --},
   {
     "neovim/nvim-lspconfig",
-    event = { "BufRead", "BufNewFile" },
     config = function()
       require("config.lsp")
     end,


### PR DESCRIPTION
It seems that for nvim 0.11.2, if you open nvim and then use fzf-lua to open a file, the filetype event is not set. This has something to do with changes in this PR: https://github.com/neovim/neovim/pull/33702. See also this post: https://www.reddit.com/r/neovim/comments/1l7pz1l/starting_from_0112_i_have_a_weird_issue/