### PR TITLE
replace delance-langserver with official pyright executable

### DIFF
--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -119,7 +119,7 @@ vim.lsp.config("*", {
 
 -- A mapping from lsp server name to the executable name
 local enabled_lsp_servers = {
-  pyright = "delance-langserver",
+  pyright = "pyright",
   ruff = "ruff",
   lua_ls = "lua-language-server",
   -- ltex = "ltex-ls",


### PR DESCRIPTION
The LSP configuration was checking for an executable named 'delance-langserver' to enable the pyright language server. However, this does not correspond to any known or official pyright binary.

Pyright, when installed via npm, exposes the command 'pyright', and internally uses 'pyright-langserver --stdio' to start the LSP. The incorrect executable name was preventing pyright from being enabled even when correctly installed.

This commit updates the LSP server mapping to use 'pyright' instead.