### PR TITLE
update plugin specs

### DIFF
--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -379,6 +379,7 @@ local plugin_specs = {
       require("config.gitsigns")
     end,
     event = "BufRead",
+    version = "*",
   },
 
   {
@@ -599,6 +600,13 @@ local plugin_specs = {
     event = "BufReadPre",
     opts = { -- set to setup table
     },
+  },
+  {
+    "stevearc/quicker.nvim",
+    event = "FileType qf",
+    ---@module "quicker"
+    ---@type quicker.SetupOptions
+    opts = {},
   },
 }
 


### PR DESCRIPTION
- pin gitsigns to stable version, to avoid https://github.com/lewis6991/gitsigns.nvim/issues/1381
- add plugin quicker.nvim