### PR TITLE
feat: close float win more easily when not needed

### DIFF
--- a/lua/config/lsp.lua
+++ b/lua/config/lsp.lua
@@ -61,7 +61,12 @@ vim.api.nvim_create_autocmd("LspAttach", {
     end, { desc = "go to definition" })
     map("n", "<C-]>", vim.lsp.buf.definition)
     map("n", "K", function()
-      vim.lsp.buf.hover { border = "single", max_height = 25, max_width = 120 }
+      vim.lsp.buf.hover {
+        border = "single",
+        max_height = 20,
+        max_width = 130,
+        close_events = { "CursorMoved", "BufLeave", "WinLeave", "LSPDetach" },
+      }
     end)
     map("n", "<C-k>", vim.lsp.buf.signature_help)
     map("n", "<space>rn", vim.lsp.buf.rename, { desc = "varialbe rename" })

--- a/lua/diagnostic-conf.lua
+++ b/lua/diagnostic-conf.lua
@@ -20,6 +20,9 @@ diagnostic.config {
     header = "Diagnostics:",
     prefix = " ",
     border = "single",
+    max_height = 10,
+    max_width = 130,
+    close_events = { "CursorMoved", "BufLeave", "WinLeave" },
   },
 }
 
@@ -58,7 +61,7 @@ api.nvim_create_autocmd("CursorHold", {
     local cursor_pos = api.nvim_win_get_cursor(0)
 
     if not vim.deep_equal(cursor_pos, vim.b.diagnostics_pos) then
-      diagnostic.open_float { width = 100 }
+      diagnostic.open_float {}
     end
 
     vim.b.diagnostics_pos = cursor_pos

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -240,3 +240,9 @@ end)
 keymap.set("n", "Q", "q", {
   desc = "Record macro",
 })
+
+keymap.set("n", "<Esc>", function()
+  vim.cmd("fclose!")
+end, {
+  desc = "close floating win",
+})


### PR DESCRIPTION
- use `close_events` to close floating win created by hover or diagnostics easily
- define a mapping for `<Esc>` to dismiss all floating win