### PR TITLE
Bump supported nvim version to 0.11.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
       <img alt="Windows" src="https://img.shields.io/badge/Windows-%23.svg?style=flat-square&logo=windows&color=0078D6&logoColor=white" />
     </a>
     <a href="https://github.com/neovim/neovim/releases/tag/stable">
-      <img src="https://img.shields.io/badge/Neovim-0.11.3-blueviolet.svg?style=flat-square&logo=Neovim&logoColor=green" alt="Neovim minimum version"/>
+      <img src="https://img.shields.io/badge/Neovim-0.11.4-blueviolet.svg?style=flat-square&logo=Neovim&logoColor=green" alt="Neovim minimum version"/>
     </a>
     <a href="https://github.com/jdhao/nvim-config/search?l=vim-script">
       <img src="https://img.shields.io/github/languages/top/jdhao/nvim-config" alt="Top languages"/>

--- a/init.lua
+++ b/init.lua
@@ -13,7 +13,7 @@ vim.loader.enable()
 
 local utils = require("utils")
 
-local expected_version = "0.11.3"
+local expected_version = "0.11.4"
 utils.is_compatible_version(expected_version)
 
 local config_dir = vim.fn.stdpath("config")

--- a/lua/globals.lua
+++ b/lua/globals.lua
@@ -1,6 +1,3 @@
-local fn = vim.fn
-local api = vim.api
-
 local utils = require("utils")
 
 ------------------------------------------------------------------------
@@ -19,18 +16,6 @@ vim.g.loaded_perl_provider = 0 -- Disable perl provider
 vim.g.loaded_ruby_provider = 0 -- Disable ruby provider
 vim.g.loaded_node_provider = 0 -- Disable node provider
 vim.g.did_install_default_menus = 1 -- do not load menu
-
-if utils.executable("python3") then
-  if vim.g.is_win then
-    vim.g.python3_host_prog = fn.substitute(fn.exepath("python3"), ".exe$", "", "g")
-  else
-    vim.g.python3_host_prog = fn.exepath("python3")
-  end
-else
-  local msg = "Python3 executable not found! You must install Python3 and set its PATH correctly!"
-  api.nvim_echo({ { msg } }, true, { err = true })
-  return
-end
 
 -- Custom mapping <leader> (see `:h mapleader` for more info)
 vim.g.mapleader = ","


### PR DESCRIPTION
Note that for nvim to pick up the correct python inside virtual env, we need to install pynvim 0.6+:

```
# the tag version is old, we can install directly from main branch
pip install git+https://github.com/neovim/pynvim.git
```