### PR TITLE
add filetypes to pyright

### DIFF
--- a/after/lsp/pyright.lua
+++ b/after/lsp/pyright.lua
@@ -21,6 +21,7 @@ local new_capability = {
 
 return {
   cmd = { "delance-langserver", "--stdio" },
+  filetypes = { "python" },
   settings = {
     pyright = {
       -- disable import sorting and use Ruff for this


### PR DESCRIPTION
Otherwise, delance-langserver will be activated for any file types.