### PR TITLE
remove mappings for adding a blank line

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -49,18 +49,6 @@ end, {
   desc = "delete other buffers",
 })
 
--- Insert a blank line below or above current line (do not move the cursor),
--- see https://stackoverflow.com/a/16136133/6064933
-keymap.set("n", "<space>o", "printf('m`%so<ESC>``', v:count1)", {
-  expr = true,
-  desc = "insert line below",
-})
-
-keymap.set("n", "<space>O", "printf('m`%sO<ESC>``', v:count1)", {
-  expr = true,
-  desc = "insert line above",
-})
-
 -- Move the cursor based on physical lines, not the actual lines.
 keymap.set("n", "j", "v:count == 0 ? 'gj' : 'j'", { expr = true })
 keymap.set("n", "k", "v:count == 0 ? 'gk' : 'k'", { expr = true })


### PR DESCRIPTION
Nvim has builtin mapping for these:

- `[<space>`: add a blank line above
- `]<space>`: add a blank line below