### PR TITLE
ui: remove experimental vim._core.ui2 configuration

### DIFF
--- a/lua/ui.lua
+++ b/lua/ui.lua
@@ -145,28 +145,4 @@ end
 
 M.rand_colorscheme()
 
--- enable the experiment UI
-require("vim._core.ui2").enable {
-  enable = true,
-  msg = { -- Options related to the message module.
-    targets = {
-      [""] = "cmd",
-      empty = "msg",
-    },
-    cmd = { -- Options related to messages in the cmdline window.
-      height = 0.2, -- Maximum height while expanded for messages beyond 'cmdheight'.
-    },
-    dialog = { -- Options related to dialog window.
-      height = 0.2, -- Maximum height.
-    },
-    msg = { -- Options related to msg window.
-      height = 0.2, -- Maximum height.
-      timeout = 1000, -- Time a message is visible in the message window.
-    },
-    pager = { -- Options related to message window.
-      height = 0.3, -- Maximum height.
-    },
-  },
-}
-
 return M


### PR DESCRIPTION
In Neovim 0.12+, vim._core.ui2's cmdline_show event handler attempts to syntax highlight command-line inputs using Tree-sitter. Due to changes in the vim grammar, it triggers a Tree-sitter query error ("Invalid node type 'tab'") and a Lua traceback whenever entering command-line mode (i.e. :).

Removing vim._core.ui2 restores Neovim's standard built-in command-line interface and prevents these crashes.

```
ERR 2026-08-12T12:21:37.085 nvim.1378658.0 ui_attach_error:783: Error in "cmdline_show" UI event handler (ns=nvim.ui2):
Lua: ...x-x86_64/share/nvim/runtime/lua/vim/treesitter/query.lua:374: Query error at 113:4. Invalid node type "tab":
    "tab"
    ^
stack traceback:
    [C]: in function '_ts_parse_query'
    ...-x86_64/share/nvim/runtime/lua/vim/_core/ui2/cmdline.lua:70: in function 'fn'
    ...4/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:717: in function 'for_each_tree'
    ...-x86_64/share/nvim/runtime/lua/vim/_core/ui2/cmdline.lua:69: in function 'set_text'
    ...-x86_64/share/nvim/runtime/lua/vim/_core/ui2/cmdline.lua:105: in function 'handler'
```