### PR TITLE
Adding debugger 

### DIFF
--- a/lua/config/blink-cmp.lua
+++ b/lua/config/blink-cmp.lua
@@ -25,7 +25,7 @@ require("blink.cmp").setup {
       winhighlight = "Normal:BlinkCmpMenu,FloatBorder:FloatBorder,CursorLine:BlinkCmpMenuSelection,Search:None",
     },
     documentation = {
-      auto_show = true,
+      auto_show = false,
     },
   },
 
@@ -95,14 +95,4 @@ require("blink.cmp").setup {
   --
   -- See the fuzzy documentation for more information
   fuzzy = { implementation = "prefer_rust_with_warning" },
-  cmdline = {
-    completion = {
-      menu = {
-        auto_show = true,
-      },
-    },
-    keymap = {
-      ["<CR>"] = { "select_and_accept", "fallback" },
-    },
-  },
 }

--- a/lua/config/dap-python.lua
+++ b/lua/config/dap-python.lua
@@ -1,0 +1,22 @@
+-- Requires `debugpy` installed in whichever Python interpreter is resolved
+-- below, e.g.: `<python> -m pip install debugpy`.
+
+-- Prefer the currently active virtualenv, then a project-local `.venv`, then
+-- fall back to the interpreter configured for Neovim's python provider, so
+-- stepping into imported modules resolves against the same environment the
+-- project actually runs with.
+local function resolve_python()
+  local venv = os.getenv("VIRTUAL_ENV")
+  if venv then
+    return vim.fs.joinpath(venv, "bin", "python3")
+  end
+
+  local project_venv = vim.fs.joinpath(vim.fn.getcwd(), ".venv", "bin", "python3")
+  if vim.uv.fs_stat(project_venv) then
+    return project_venv
+  end
+
+  return vim.g.python3_host_prog or "python3"
+end
+
+require("dap-python").setup(resolve_python())

--- a/lua/config/dap.lua
+++ b/lua/config/dap.lua
@@ -1,0 +1,38 @@
+local dap = require("dap")
+local dapui = require("dapui")
+
+dapui.setup()
+require("nvim-dap-virtual-text").setup {}
+
+-- Automatically open/close the UI panels (scopes, stack, breakpoints, repl)
+-- around a debug session, similar to VS Code's debug view.
+dap.listeners.after.event_initialized["dapui_config"] = function()
+  dapui.open()
+end
+dap.listeners.before.event_terminated["dapui_config"] = function()
+  dapui.close()
+end
+dap.listeners.before.event_exited["dapui_config"] = function()
+  dapui.close()
+end
+
+vim.fn.sign_define(
+  "DapBreakpoint",
+  { text = "●", texthl = "DiagnosticSignError", linehl = "", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapBreakpointCondition",
+  { text = "◆", texthl = "DiagnosticSignWarn", linehl = "", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapLogPoint",
+  { text = "◆", texthl = "DiagnosticSignInfo", linehl = "", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapStopped",
+  { text = "▶", texthl = "DiagnosticSignWarn", linehl = "Visual", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapBreakpointRejected",
+  { text = "✗", texthl = "DiagnosticSignError", linehl = "", numhl = "" }
+)

--- a/lua/custom-autocmd.lua
+++ b/lua/custom-autocmd.lua
@@ -196,32 +196,6 @@ api.nvim_create_autocmd("ColorScheme", {
   end,
 })
 
-api.nvim_create_autocmd("BufEnter", {
-  pattern = "*",
-  group = api.nvim_create_augroup("auto_close_win", { clear = true }),
-  desc = "Quit Nvim if we have only one window, and its filetype match our pattern",
-  ---@diagnostic disable-next-line: unused-local
-  callback = function(context)
-    local quit_filetypes = { "qf", "NvimTree" }
-
-    local should_quit = true
-    local tabwins = api.nvim_tabpage_list_wins(0)
-
-    for _, win in pairs(tabwins) do
-      local buf = api.nvim_win_get_buf(win)
-      local buf_type = vim.api.nvim_get_option_value("filetype", { buf = buf })
-
-      if not vim.tbl_contains(quit_filetypes, buf_type) then
-        should_quit = false
-      end
-    end
-
-    if should_quit then
-      vim.cmd("qall")
-    end
-  end,
-})
-
 api.nvim_create_autocmd({ "VimEnter", "DirChanged" }, {
   group = api.nvim_create_augroup("git_repo_check", { clear = true }),
   pattern = "*",
@@ -289,20 +263,6 @@ api.nvim_create_autocmd("BufWritePost", {
     local result = vim.system(cmd, { text = true }):wait()
     if result.code ~= 0 then
       vim.notify("This file is not formatted!")
-    end
-  end,
-})
-
-api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
-  group = api.nvim_create_augroup("auto_save", { clear = true }),
-  pattern = { "*" },
-  desc = "Auto save current file",
-  callback = function(ev)
-    local is_readonly = vim.api.nvim_get_option_value("readonly", { buf = ev.buf })
-    local is_modifiable = vim.api.nvim_get_option_value("modifiable", { buf = ev.buf })
-
-    if not is_readonly and is_modifiable then
-      vim.cmd([[silent! update]])
     end
   end,
 })

--- a/lua/globals.lua
+++ b/lua/globals.lua
@@ -1,8 +1,7 @@
 local utils = require("utils")
 
 -- python3_host_prog is needed for python plugins, see also https://jdhao.github.io/2026/05/11/nvim_python_provider_setup/
-local config_path = vim.fn.stdpath("config")
-local python3_path = vim.fs.joinpath(config_path, ".venv/bin/python3")
+local python3_path = vim.fn.expand("~/miniconda3/envs/nvim/bin/python3")
 if not vim.uv.fs_stat(python3_path) then
   local msg = string.format(
     "Python provider missing:\n  create a virtual env under nvim config and install pynvim!"

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -257,3 +257,58 @@ keymap.set("n", "<Esc>", function()
 end, {
   desc = "close floating win",
 })
+
+-- Debugging (nvim-dap), mirrors VS Code's common debug keys/behavior
+keymap.set("n", "<F5>", function()
+  require("dap").continue()
+end, { desc = "debug: continue/start" })
+
+keymap.set("n", "<F10>", function()
+  require("dap").step_over()
+end, { desc = "debug: step over" })
+
+keymap.set("n", "<F12>", function()
+  require("dap").step_out()
+end, { desc = "debug: step out" })
+
+-- F11 is commonly intercepted by the terminal/window manager for fullscreen
+-- before it ever reaches Neovim, so step-into lives under <leader>d instead.
+keymap.set("n", "<leader>di", function()
+  require("dap").step_into()
+end, { desc = "debug: step into (enters imported modules)" })
+
+keymap.set("n", "<leader>do", function()
+  require("dap").step_over()
+end, { desc = "debug: step over" })
+
+keymap.set("n", "<leader>dO", function()
+  require("dap").step_out()
+end, { desc = "debug: step out" })
+
+keymap.set("n", "<leader>db", function()
+  require("dap").toggle_breakpoint()
+end, { desc = "debug: toggle breakpoint" })
+
+keymap.set("n", "<leader>dB", function()
+  require("dap").set_breakpoint(vim.fn.input("Breakpoint condition: "))
+end, { desc = "debug: conditional breakpoint" })
+
+keymap.set("n", "<leader>dr", function()
+  require("dap").repl.toggle()
+end, { desc = "debug: toggle REPL" })
+
+keymap.set("n", "<leader>dl", function()
+  require("dap").run_last()
+end, { desc = "debug: run last session" })
+
+keymap.set("n", "<leader>dt", function()
+  require("dap").terminate()
+end, { desc = "debug: terminate session" })
+
+keymap.set("n", "<leader>du", function()
+  require("dapui").toggle()
+end, { desc = "debug: toggle UI (variables/stack/breakpoints)" })
+
+keymap.set("n", "<leader>dh", function()
+  require("dap.ui.widgets").hover()
+end, { desc = "debug: hover variable value" })

--- a/lua/options.lua
+++ b/lua/options.lua
@@ -147,9 +147,10 @@ opt.listchars = {
   nbsp = "␣",
 }
 
--- Auto-write the file based on some condition
-opt.autowrite = true
-opt.autowriteall = true
+-- Keep vanilla behavior: `:q` should refuse and warn on unsaved changes,
+-- only `:q!` should discard them.
+opt.autowrite = false
+opt.autowriteall = false
 
 -- Auto reload file if changed outside nvim
 opt.autoread = true

--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -801,6 +801,20 @@ local plugin_specs = {
       require("config.colorful_menu")
     end,
   },
+  {
+    "mfussenegger/nvim-dap",
+    dependencies = {
+      "rcarriga/nvim-dap-ui",
+      "nvim-neotest/nvim-nio",
+      "mfussenegger/nvim-dap-python",
+      "theHamsta/nvim-dap-virtual-text",
+    },
+    event = "VeryLazy",
+    config = function()
+      require("config.dap")
+      require("config.dap-python")
+    end,
+  },
 }
 
 if completion_engine == "nvim-cmp" then

--- a/lua/ui.lua
+++ b/lua/ui.lua
@@ -1,7 +1,10 @@
---- This module will load a random colorscheme on nvim startup process.
-local utils = require("utils")
-
+--- This module loads a static colorscheme on nvim startup.
+--- Use `:colorscheme <name>` to switch between the configured schemes below.
 local M = {}
+
+--- The colorscheme to load on startup. Change this key to any of the names
+--- defined in M.colorscheme_conf below.
+M.default_colorscheme = "onedark"
 
 local use_theme = function(name)
   local ok, err = pcall(vim.cmd.colorscheme, name)
@@ -129,21 +132,46 @@ M.colorscheme_conf = {
   end,
 }
 
---- Use a random colorscheme from the pre-defined list of colorschemes.
-M.rand_colorscheme = function()
-  local colorscheme_names = vim.tbl_keys(M.colorscheme_conf)
-  local colorscheme = utils.rand_element(colorscheme_names)
+--- Apply a colorscheme by name, running its pre-defined setup (options like
+--- background, italics, etc.) if one exists in M.colorscheme_conf, or falling
+--- back to a plain `:colorscheme` for anything else installed.
+M.apply_colorscheme = function(name)
+  local loader = M.colorscheme_conf[name]
 
-  -- Load the colorscheme and its settings
-
-  local color_scheme_loader = M.colorscheme_conf[colorscheme]
-
-  color_scheme_loader()
-
-  return colorscheme
+  if loader then
+    loader()
+  else
+    use_theme(name)
+  end
 end
 
-M.rand_colorscheme()
+-- Let `:colorscheme <name>` pick up the pre-defined setup for known schemes
+-- (e.g. italics, background variant) instead of just switching highlights.
+vim.api.nvim_create_autocmd("ColorSchemePre", {
+  callback = function(args)
+    local loader = M.colorscheme_conf[args.match]
+    if loader and not M._applying then
+      M._applying = true
+      loader()
+      M._applying = false
+    end
+  end,
+})
+
+M.apply_colorscheme(M.default_colorscheme)
+
+-- `:Colorscheme <name>` accepts the friendly keys from M.colorscheme_conf
+-- (which may differ from the actual installed colorscheme name), applying
+-- their pre-defined setup. Native `:colorscheme` still works for any
+-- installed theme by its real name.
+vim.api.nvim_create_user_command("Colorscheme", function(opts)
+  M.apply_colorscheme(opts.args)
+end, {
+  nargs = 1,
+  complete = function()
+    return vim.tbl_keys(M.colorscheme_conf)
+  end,
+})
 
 -- enable the experiment UI
 require("vim._core.ui2").enable {


### PR DESCRIPTION
feat(dap): add nvim-dap debugger with Python support

Add nvim-dap + nvim-dap-ui + nvim-dap-virtual-text + nvim-dap-python,
giving a VS Code-like debugging experience: breakpoints, step
in/over/out (including into imported modules), live variable
inspection in a dedicated UI, and inline virtual-text values.
dap-python resolves the interpreter from $VIRTUAL_ENV, a project-local
.venv, or the configured python3_host_prog, in that order, so
`debugpy` (must be installed in that interpreter) matches the
project's actual environment.