### PR TITLE
feat(dap): add nvim-dap debugger with Python support

### DIFF
--- a/lua/config/dap-python.lua
+++ b/lua/config/dap-python.lua
@@ -1,0 +1,22 @@
+-- Requires `debugpy` installed in whichever Python interpreter is resolved
+-- below, e.g.: `<python> -m pip install debugpy`.
+
+-- Prefer the currently active virtualenv, then a project-local `.venv`, then
+-- fall back to the interpreter configured for Neovim's python provider, so
+-- stepping into imported modules resolves against the same environment the
+-- project actually runs with.
+local function resolve_python()
+  local venv = os.getenv("VIRTUAL_ENV")
+  if venv then
+    return vim.fs.joinpath(venv, "bin", "python3")
+  end
+
+  local project_venv = vim.fs.joinpath(vim.fn.getcwd(), ".venv", "bin", "python3")
+  if vim.uv.fs_stat(project_venv) then
+    return project_venv
+  end
+
+  return vim.g.python3_host_prog or "python3"
+end
+
+require("dap-python").setup(resolve_python())

--- a/lua/config/dap.lua
+++ b/lua/config/dap.lua
@@ -1,0 +1,38 @@
+local dap = require("dap")
+local dapui = require("dapui")
+
+dapui.setup()
+require("nvim-dap-virtual-text").setup {}
+
+-- Automatically open/close the UI panels (scopes, stack, breakpoints, repl)
+-- around a debug session, similar to VS Code's debug view.
+dap.listeners.after.event_initialized["dapui_config"] = function()
+  dapui.open()
+end
+dap.listeners.before.event_terminated["dapui_config"] = function()
+  dapui.close()
+end
+dap.listeners.before.event_exited["dapui_config"] = function()
+  dapui.close()
+end
+
+vim.fn.sign_define(
+  "DapBreakpoint",
+  { text = "●", texthl = "DiagnosticSignError", linehl = "", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapBreakpointCondition",
+  { text = "◆", texthl = "DiagnosticSignWarn", linehl = "", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapLogPoint",
+  { text = "◆", texthl = "DiagnosticSignInfo", linehl = "", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapStopped",
+  { text = "▶", texthl = "DiagnosticSignWarn", linehl = "Visual", numhl = "" }
+)
+vim.fn.sign_define(
+  "DapBreakpointRejected",
+  { text = "✗", texthl = "DiagnosticSignError", linehl = "", numhl = "" }
+)

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -257,3 +257,58 @@ keymap.set("n", "<Esc>", function()
 end, {
   desc = "close floating win",
 })
+
+-- Debugging (nvim-dap), mirrors VS Code's common debug keys/behavior
+keymap.set("n", "<F5>", function()
+  require("dap").continue()
+end, { desc = "debug: continue/start" })
+
+keymap.set("n", "<F10>", function()
+  require("dap").step_over()
+end, { desc = "debug: step over" })
+
+keymap.set("n", "<F12>", function()
+  require("dap").step_out()
+end, { desc = "debug: step out" })
+
+-- F11 is commonly intercepted by the terminal/window manager for fullscreen
+-- before it ever reaches Neovim, so step-into lives under <leader>d instead.
+keymap.set("n", "<leader>di", function()
+  require("dap").step_into()
+end, { desc = "debug: step into (enters imported modules)" })
+
+keymap.set("n", "<leader>do", function()
+  require("dap").step_over()
+end, { desc = "debug: step over" })
+
+keymap.set("n", "<leader>dO", function()
+  require("dap").step_out()
+end, { desc = "debug: step out" })
+
+keymap.set("n", "<leader>db", function()
+  require("dap").toggle_breakpoint()
+end, { desc = "debug: toggle breakpoint" })
+
+keymap.set("n", "<leader>dB", function()
+  require("dap").set_breakpoint(vim.fn.input("Breakpoint condition: "))
+end, { desc = "debug: conditional breakpoint" })
+
+keymap.set("n", "<leader>dr", function()
+  require("dap").repl.toggle()
+end, { desc = "debug: toggle REPL" })
+
+keymap.set("n", "<leader>dl", function()
+  require("dap").run_last()
+end, { desc = "debug: run last session" })
+
+keymap.set("n", "<leader>dt", function()
+  require("dap").terminate()
+end, { desc = "debug: terminate session" })
+
+keymap.set("n", "<leader>du", function()
+  require("dapui").toggle()
+end, { desc = "debug: toggle UI (variables/stack/breakpoints)" })
+
+keymap.set("n", "<leader>dh", function()
+  require("dap.ui.widgets").hover()
+end, { desc = "debug: hover variable value" })

--- a/lua/plugin_specs.lua
+++ b/lua/plugin_specs.lua
@@ -801,6 +801,20 @@ local plugin_specs = {
       require("config.colorful_menu")
     end,
   },
+  {
+    "mfussenegger/nvim-dap",
+    dependencies = {
+      "rcarriga/nvim-dap-ui",
+      "nvim-neotest/nvim-nio",
+      "mfussenegger/nvim-dap-python",
+      "theHamsta/nvim-dap-virtual-text",
+    },
+    event = "VeryLazy",
+    config = function()
+      require("config.dap")
+      require("config.dap-python")
+    end,
+  },
 }
 
 if completion_engine == "nvim-cmp" then


### PR DESCRIPTION
## Summary
Adds nvim-dap + nvim-dap-ui + nvim-dap-virtual-text + nvim-dap-python,
providing a VS Code-like debugging experience: breakpoints, step
in/over/out (including into imported modules), live variable
inspection in a dedicated UI panel, and inline virtual-text values.

## Interpreter resolution
dap-python resolves the Python interpreter in this order:
1. `$VIRTUAL_ENV`
2. a project-local `.venv`
3. the configured `python3_host_prog` (fallback)

`debugpy` must be installed in whichever interpreter is actually
resolved for a given project.

## Known limitation
<!-- TODO: confirm this before merging -->
If a project has no `$VIRTUAL_ENV` and no local `.venv`, resolution
falls back to `python3_host_prog` — the interpreter dedicated to the
Neovim provider (pynvim), which does NOT have `debugpy` installed.
Need to verify: does this fail with a clear error message, or fail
silently? If silent, this should be fixed before merge (e.g. explicit
check + user-facing warning when falling back without debugpy present).

## Testing
Manually tested breakpoints and stepping on a project with a local
`.venv` containing debugpy.