### PR TITLE
Chore/vanilla preferences

### DIFF
--- a/lua/custom-autocmd.lua
+++ b/lua/custom-autocmd.lua
@@ -196,32 +196,6 @@ api.nvim_create_autocmd("ColorScheme", {
   end,
 })
 
-api.nvim_create_autocmd("BufEnter", {
-  pattern = "*",
-  group = api.nvim_create_augroup("auto_close_win", { clear = true }),
-  desc = "Quit Nvim if we have only one window, and its filetype match our pattern",
-  ---@diagnostic disable-next-line: unused-local
-  callback = function(context)
-    local quit_filetypes = { "qf", "NvimTree" }
-
-    local should_quit = true
-    local tabwins = api.nvim_tabpage_list_wins(0)
-
-    for _, win in pairs(tabwins) do
-      local buf = api.nvim_win_get_buf(win)
-      local buf_type = vim.api.nvim_get_option_value("filetype", { buf = buf })
-
-      if not vim.tbl_contains(quit_filetypes, buf_type) then
-        should_quit = false
-      end
-    end
-
-    if should_quit then
-      vim.cmd("qall")
-    end
-  end,
-})
-
 api.nvim_create_autocmd({ "VimEnter", "DirChanged" }, {
   group = api.nvim_create_augroup("git_repo_check", { clear = true }),
   pattern = "*",
@@ -289,20 +263,6 @@ api.nvim_create_autocmd("BufWritePost", {
     local result = vim.system(cmd, { text = true }):wait()
     if result.code ~= 0 then
       vim.notify("This file is not formatted!")
-    end
-  end,
-})
-
-api.nvim_create_autocmd({ "InsertLeave", "TextChanged" }, {
-  group = api.nvim_create_augroup("auto_save", { clear = true }),
-  pattern = { "*" },
-  desc = "Auto save current file",
-  callback = function(ev)
-    local is_readonly = vim.api.nvim_get_option_value("readonly", { buf = ev.buf })
-    local is_modifiable = vim.api.nvim_get_option_value("modifiable", { buf = ev.buf })
-
-    if not is_readonly and is_modifiable then
-      vim.cmd([[silent! update]])
     end
   end,
 })

--- a/lua/ui.lua
+++ b/lua/ui.lua
@@ -1,7 +1,10 @@
---- This module will load a random colorscheme on nvim startup process.
-local utils = require("utils")
-
+--- This module loads a static colorscheme on nvim startup.
+--- Use `:colorscheme <name>` to switch between the configured schemes below.
 local M = {}
+
+--- The colorscheme to load on startup. Change this key to any of the names
+--- defined in M.colorscheme_conf below.
+M.default_colorscheme = "onedark"
 
 local use_theme = function(name)
   local ok, err = pcall(vim.cmd.colorscheme, name)
@@ -129,21 +132,46 @@ M.colorscheme_conf = {
   end,
 }
 
---- Use a random colorscheme from the pre-defined list of colorschemes.
-M.rand_colorscheme = function()
-  local colorscheme_names = vim.tbl_keys(M.colorscheme_conf)
-  local colorscheme = utils.rand_element(colorscheme_names)
+--- Apply a colorscheme by name, running its pre-defined setup (options like
+--- background, italics, etc.) if one exists in M.colorscheme_conf, or falling
+--- back to a plain `:colorscheme` for anything else installed.
+M.apply_colorscheme = function(name)
+  local loader = M.colorscheme_conf[name]
 
-  -- Load the colorscheme and its settings
-
-  local color_scheme_loader = M.colorscheme_conf[colorscheme]
-
-  color_scheme_loader()
-
-  return colorscheme
+  if loader then
+    loader()
+  else
+    use_theme(name)
+  end
 end
 
-M.rand_colorscheme()
+-- Let `:colorscheme <name>` pick up the pre-defined setup for known schemes
+-- (e.g. italics, background variant) instead of just switching highlights.
+vim.api.nvim_create_autocmd("ColorSchemePre", {
+  callback = function(args)
+    local loader = M.colorscheme_conf[args.match]
+    if loader and not M._applying then
+      M._applying = true
+      loader()
+      M._applying = false
+    end
+  end,
+})
+
+M.apply_colorscheme(M.default_colorscheme)
+
+-- `:Colorscheme <name>` accepts the friendly keys from M.colorscheme_conf
+-- (which may differ from the actual installed colorscheme name), applying
+-- their pre-defined setup. Native `:colorscheme` still works for any
+-- installed theme by its real name.
+vim.api.nvim_create_user_command("Colorscheme", function(opts)
+  M.apply_colorscheme(opts.args)
+end, {
+  nargs = 1,
+  complete = function()
+    return vim.tbl_keys(M.colorscheme_conf)
+  end,
+})
 
 -- enable the experiment UI
 require("vim._core.ui2").enable {


### PR DESCRIPTION
## Summary
Personal configuration preferences, moving toward a more vanilla
Neovim experience. Not upstream candidates — these remove behavior
that worked as designed but that this fork's author does not want.

## Changes

- **ui.lua**: replaced random colorscheme selection on startup with
  a static default (`M.default_colorscheme`). Users can still switch
  themes at runtime via native `:colorscheme <name>` (any installed
  theme) or `:Colorscheme <key>` (applies the pre-defined setup from
  `M.colorscheme_conf` for a given key, which may differ from the
  theme's real name).

- **custom-autocmd.lua**: removed auto-save and auto-close-window
  autocmds. These were intentional features of the upstream config,
  not bugs — removed here to reduce implicit/magic behavior.

## Note for reviewers
This PR is fork-specific and not intended to be proposed upstream.